### PR TITLE
Testing GitHub CI with bad python file

### DIFF
--- a/bad.py
+++ b/bad.py
@@ -1,0 +1,1 @@
+<<<This file is not a legal Python file>>>


### PR DESCRIPTION
- 'bad.py' has illegal python syntax. This should cause flake8 check
  to fail.